### PR TITLE
GH-25 initialize OpenGL context and 2D renderer prerequisites

### DIFF
--- a/engine/src/main/java/net/sparkzz/entropy/EntropyEngine.java
+++ b/engine/src/main/java/net/sparkzz/entropy/EntropyEngine.java
@@ -11,6 +11,7 @@ import java.nio.IntBuffer;
 
 import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
 import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.opengl.GL.createCapabilities;
 import static org.lwjgl.system.MemoryStack.stackPush;
 
 /**
@@ -63,6 +64,11 @@ public class EntropyEngine {
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
         glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
 
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+
         window = glfwCreateWindow(WINDOW_WIDTH, WINDOW_HEIGHT, windowTitle, 0L, 0L);
 
         if (window == 0L) throw new RuntimeException("Failed to create the GLFW window");
@@ -82,6 +88,7 @@ public class EntropyEngine {
             );
 
             glfwMakeContextCurrent(window);
+            createCapabilities();
             glfwSwapInterval(1); // Enable v-sync
             glfwShowWindow(window);
         }

--- a/engine/src/main/java/net/sparkzz/entropy/render/Texture.java
+++ b/engine/src/main/java/net/sparkzz/entropy/render/Texture.java
@@ -5,6 +5,7 @@ import org.lwjgl.system.MemoryStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
@@ -36,15 +37,25 @@ public class Texture {
     public Texture(String path) {
         logger.info("Loading texture from path: {}", path);
 
+        ByteBuffer imageBuffer;
+        try (InputStream is = getClass().getResourceAsStream(path)) {
+            if (is == null)
+                throw new RuntimeException("Texture resource not found: " + path);
+            byte[] bytes = is.readAllBytes();
+            imageBuffer = org.lwjgl.system.MemoryUtil.memAlloc(bytes.length);
+            imageBuffer.put(bytes).flip();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load texture resource: " + path, e);
+        }
+
         try (MemoryStack stack = MemoryStack.stackPush()) {
             IntBuffer width = stack.mallocInt(1);
             IntBuffer height = stack.mallocInt(1);
             IntBuffer components = stack.mallocInt(1);
 
-            // Flip Y axis to match OpenGL's coordinate system
             STBImage.stbi_set_flip_vertically_on_load(true);
 
-            ByteBuffer data = STBImage.stbi_load(path, width, height, components, 4);
+            ByteBuffer data = STBImage.stbi_load_from_memory(imageBuffer, width, height, components, 4);
 
             if (data == null)
                 throw new RuntimeException("Failed to load texture file: " + path
@@ -64,6 +75,8 @@ public class Texture {
 
             STBImage.stbi_image_free(data);
             unbind();
+        } finally {
+            org.lwjgl.system.MemoryUtil.memFree(imageBuffer);
         }
     }
 

--- a/engine/src/main/java/net/sparkzz/entropy/render/Texture.java
+++ b/engine/src/main/java/net/sparkzz/entropy/render/Texture.java
@@ -51,7 +51,11 @@ public class Texture {
         ByteBuffer pixel = MemoryUtil.memAlloc(4);
 
         try {
-            pixel.put((byte) (r * 255)).put((byte) (g * 255)).put((byte) (b * 255)).put((byte) (a * 255)).flip();
+            pixel.put((byte) (int) (Math.clamp(r, 0f, 1f) * 255))
+                 .put((byte) (int) (Math.clamp(g, 0f, 1f) * 255))
+                 .put((byte) (int) (Math.clamp(b, 0f, 1f) * 255))
+                 .put((byte) (int) (Math.clamp(a, 0f, 1f) * 255))
+                 .flip();
 
             glBindTexture(GL_TEXTURE_2D, id);
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixel);
@@ -103,18 +107,23 @@ public class Texture {
             this.height = height.get(0);
             this.id = glGenTextures();
 
-            bind();
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, this.width, this.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-            glGenerateMipmap(GL_TEXTURE_2D);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-            STBImage.stbi_image_free(data);
-            unbind();
+            try {
+                bind();
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, this.width, this.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+                glGenerateMipmap(GL_TEXTURE_2D);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+                glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            } catch (RuntimeException e) {
+                glDeleteTextures(this.id);
+                throw e;
+            } finally {
+                STBImage.stbi_image_free(data);
+                unbind();
+            }
         } finally {
-            org.lwjgl.system.MemoryUtil.memFree(imageBuffer);
+            MemoryUtil.memFree(imageBuffer);
         }
     }
 

--- a/engine/src/main/java/net/sparkzz/entropy/render/Texture.java
+++ b/engine/src/main/java/net/sparkzz/entropy/render/Texture.java
@@ -2,6 +2,7 @@ package net.sparkzz.entropy.render;
 
 import org.lwjgl.stb.STBImage;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +29,43 @@ public class Texture {
     private final int id;
     private final int width;
     private final int height;
+
+    private Texture(int id, int width, int height) {
+        this.id = id;
+        this.width = width;
+        this.height = height;
+    }
+
+    /**
+     * Creates a 1x1 solid-color texture from the given RGBA components.
+     * Useful for rendering untextured quads or as a placeholder texture.
+     *
+     * @param r Red component (0.0–1.0).
+     * @param g Green component (0.0–1.0).
+     * @param b Blue component (0.0–1.0).
+     * @param a Alpha component (0.0–1.0).
+     * @return A new Texture backed by a 1x1 RGBA pixel.
+     */
+    public static Texture ofColor(float r, float g, float b, float a) {
+        int id = glGenTextures();
+        ByteBuffer pixel = MemoryUtil.memAlloc(4);
+
+        try {
+            pixel.put((byte) (r * 255)).put((byte) (g * 255)).put((byte) (b * 255)).put((byte) (a * 255)).flip();
+
+            glBindTexture(GL_TEXTURE_2D, id);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixel);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glBindTexture(GL_TEXTURE_2D, 0);
+        } finally {
+            MemoryUtil.memFree(pixel);
+        }
+
+        return new Texture(id, 1, 1);
+    }
 
     /**
      * Loads a texture from the specified file path.

--- a/engine/src/main/resources/shaders/default_2d_fragment.glsl
+++ b/engine/src/main/resources/shaders/default_2d_fragment.glsl
@@ -1,0 +1,9 @@
+#version 330 core
+
+out vec4 color;
+
+uniform vec4 uColor;
+
+void main() {
+    color = uColor;
+}

--- a/engine/src/main/resources/shaders/default_2d_vertex.glsl
+++ b/engine/src/main/resources/shaders/default_2d_vertex.glsl
@@ -1,0 +1,10 @@
+#version 330 core
+
+layout(location = 0) in vec3 position;
+
+uniform mat4 uProjection;
+uniform mat4 uModel;
+
+void main() {
+    gl_Position = uProjection * uModel * vec4(position, 1.0);
+}

--- a/engine/src/test/java/net/sparkzz/entropy/demo/DemoRender2D.java
+++ b/engine/src/test/java/net/sparkzz/entropy/demo/DemoRender2D.java
@@ -44,10 +44,10 @@ public class DemoRender2D implements IEntropyGame {
         );
 
         element = new UIElement(
-                Texture.ofColor(0.2f, 0.6f, 1f, 1f),
+                Texture.ofColor(1f, 1f, 1f, 1f),
                 new Vector2f(0f, 0f),
                 new Vector2f(0.25f, 0.25f),
-                new Vector4f(1f, 1f, 1f, 1f),
+                new Vector4f(0.2f, 0.6f, 1f, 1f),
                 0f,
                 1
         );

--- a/engine/src/test/java/net/sparkzz/entropy/demo/DemoRender2D.java
+++ b/engine/src/test/java/net/sparkzz/entropy/demo/DemoRender2D.java
@@ -1,0 +1,84 @@
+package net.sparkzz.entropy.demo;
+
+import net.sparkzz.entropy.EntropyEngine;
+import net.sparkzz.entropy.IEntropyGame;
+import net.sparkzz.entropy.render.Texture;
+import net.sparkzz.entropy.render.orthographic.Render2D;
+import net.sparkzz.entropy.render.orthographic.batch.BatchType;
+import net.sparkzz.entropy.render.orthographic.camera.Camera2D;
+import net.sparkzz.entropy.render.orthographic.model.UIElement;
+import net.sparkzz.entropy.render.orthographic.shader.Shader2D;
+import org.joml.Vector2f;
+import org.joml.Vector4f;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+import static net.sparkzz.entropy.io.util.ResourceLoader.loadResourceAsString;
+
+public class DemoRender2D implements IEntropyGame {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoRender2D.class);
+
+    private Render2D renderer;
+    private UIElement element;
+    private boolean initialized = false;
+
+    private void initResources() {
+        String vertexShader, fragmentShader;
+
+        try {
+            vertexShader = loadResourceAsString("/shaders/default_2d_vertex.glsl");
+            fragmentShader = loadResourceAsString("/shaders/default_2d_fragment.glsl");
+        } catch (IOException e) {
+            log.error("Failed to load shader resources", e);
+            throw new RuntimeException("Shader resource loading failed", e);
+        }
+
+        renderer = new Render2D(
+                new Camera2D(),
+                new Shader2D(vertexShader, fragmentShader),
+                new Shader2D(vertexShader, fragmentShader)
+        );
+
+        element = new UIElement(
+                Texture.ofColor(0.2f, 0.6f, 1f, 1f),
+                new Vector2f(0f, 0f),
+                new Vector2f(0.25f, 0.25f),
+                new Vector4f(1f, 1f, 1f, 1f),
+                0f,
+                1
+        );
+
+        initialized = true;
+    }
+
+    @Override
+    public void update() {}
+
+    @Override
+    public void render() {
+        if (!initialized) initResources();
+
+        renderer.render(BatchType.UI_ELEMENT, List.of(element));
+    }
+
+    @Override
+    public String getWindowTitle() {
+        return "Render2D Demo";
+    }
+
+    public static void main(String[] args) {
+        try {
+            DemoRender2D game = new DemoRender2D();
+            EntropyEngine engine = new EntropyEngine(game);
+
+            engine.run();
+        } catch (Exception exception) {
+            log.error("An error occurred while running the Entropy Game", exception);
+            System.exit(1);
+        }
+    }
+}

--- a/engine/src/test/java/net/sparkzz/entropy/demo/DemoRender2D.java
+++ b/engine/src/test/java/net/sparkzz/entropy/demo/DemoRender2D.java
@@ -18,6 +18,15 @@ import java.util.List;
 
 import static net.sparkzz.entropy.io.util.ResourceLoader.loadResourceAsString;
 
+/**
+ * Interactive demo for manually validating the 2D orthographic renderer.
+ * Renders a solid-color quad using {@link Render2D} and the default 2D shaders.
+ * Intentionally placed in {@code src/test} so it is excluded from the distributed artifact.
+ *
+ * @author Brendon Butler
+ * @version 0.1.0-PREALPHA
+ * @since 2025-07-28
+ */
 public class DemoRender2D implements IEntropyGame {
 
     private static final Logger log = LoggerFactory.getLogger(DemoRender2D.class);
@@ -25,6 +34,7 @@ public class DemoRender2D implements IEntropyGame {
     private Render2D renderer;
     private UIElement element;
     private boolean initialized = false;
+    private boolean initFailed = false;
 
     private void initResources() {
         String vertexShader, fragmentShader;
@@ -60,7 +70,17 @@ public class DemoRender2D implements IEntropyGame {
 
     @Override
     public void render() {
-        if (!initialized) initResources();
+        if (initFailed) return;
+
+        if (!initialized) {
+            try {
+                initResources();
+            } catch (RuntimeException e) {
+                log.error("Failed to initialize rendering resources, disabling renderer", e);
+                initFailed = true;
+                return;
+            }
+        }
 
         renderer.render(BatchType.UI_ELEMENT, List.of(element));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,9 @@
         <logback.version>1.5.18</logback.version>
 
         <build.revision>${project.version}</build.revision>
+
+        <!-- platform-specific JVM args appended to Surefire; overridden per profile -->
+        <surefire.extra.args></surefire.extra.args>
     </properties>
 
     <dependencyManagement>
@@ -155,7 +158,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.3</version>
                 <configuration>
-                    <argLine>-XX:+EnableDynamicAgentLoading -Djdk.instrument.traceUsage=false -Xshare:off</argLine>
+                    <argLine>${surefire.extra.args} -XX:+EnableDynamicAgentLoading -Djdk.instrument.traceUsage=false -Xshare:off</argLine>
                 </configuration>
             </plugin>
         </plugins>
@@ -180,6 +183,7 @@
             <properties>
                 <native.classifier>natives-macos-arm64</native.classifier>
                 <platform.name>macos</platform.name>
+                <surefire.extra.args>-XstartOnFirstThread</surefire.extra.args>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
## Summary

Lays the groundwork needed for the 2D orthographic renderer to actually produce output. GH-25 is not closed by this PR — the renderer feature is ongoing; this merges the prerequisite infrastructure.

- Initialize an OpenGL 3.3 core profile context in `EntropyEngine` (`GL.createCapabilities()`, forward-compat hints)
- Fix `Texture` to load images from classpath resources via `InputStream` instead of a raw file path
- Add `Texture.ofColor(r, g, b, a)` static factory for solid-color 1×1 textures (no file required)
- Add default 2D vertex and fragment shaders (`default_2d_vertex.glsl`, `default_2d_fragment.glsl`) to `engine/src/main/resources`
- Add `DemoRender2D` to `src/test/java` as an interactive manual validation harness for the 2D renderer

## Test plan

- [x] Run `DemoRender2D.main()` — a window should open and display a blue quad
- [x] Confirm no GL errors in logs on startup or during the render loop
- [x] Existing unit tests pass (`mvn test -P macos`)

## Notes

`DemoRender2D` is intentionally in `src/test/java` so it is excluded from the distributed artifact. It uses `Texture.ofColor` to avoid bundling any third-party image assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added solid color texture creation from RGBA values
  * Added 2D rendering demonstration showcasing texture and UI element rendering

* **Improvements**
  * Enhanced OpenGL context initialization and graphics configuration for improved compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->